### PR TITLE
refactor/missing-python-library-in-requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ javalang
 tqdm
 easyargs
 colorama
+dataclasses

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ javalang
 tqdm
 easyargs
 colorama
-dataclasses
+dataclasses; python_version < '3.7'


### PR DESCRIPTION
Missing Python lib in requirements

```
Traceback (most recent call last):
  File "scan_log4j_versions.py", line 3, in <module>
    from dataclasses import dataclass
ModuleNotFoundError: No module named 'dataclasses'
```